### PR TITLE
feat: trends with coverage, Miro/Basecamp design, list/card view

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,16 @@
+# MongoDB
+MONGODB_URI=mongodb://localhost:27017
+MONGODB_DB=hanfani
+
+# Trends - SerpApi (optional: 100 free searches/month)
+# Get key at https://serpapi.com/manage-api-key
+# Required for: trending topics (fallback), topic mentions (news/articles)
+SERPAPI_KEY=
+
+# Trends - Scraper (default: scrapes trends.google.com, no API key)
+# Set to false to skip scraping and use pytrends/fallback only
+TRENDS_USE_SCRAPER=true
+
+# Trends worker (optional)
+TRENDS_COUNTRIES=US,GB,FR,DE,IN,JP,BR,CA,AU,ES,CR
+TRENDS_USE_MOCK=false

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -9,6 +9,61 @@ uvicorn main:app --reload --port 8001
 
 Use `--port 8001` if port 8000 is already in use.
 
+## MongoDB
+
+Trends are stored in MongoDB. Set env vars:
+
+- `MONGODB_URI` – default `mongodb://localhost:27017`
+- `MONGODB_DB` – default `hanfani`
+
+## Google Trends
+
+**Option 1: Scraper (default, no API key)**  
+Scrapes https://trends.google.com/trending?geo=XX using Playwright. Returns first 25 trends.
+
+```bash
+pip install playwright
+playwright install chromium
+```
+
+Set `TRENDS_USE_SCRAPER=false` to disable.
+
+**Option 2: SerpApi (100 free searches/month)**  
+Set `SERPAPI_KEY=your_key` for API-based fetching. Takes precedence over scraper.
+
+**Topic mentions (news/articles)**  
+`GET /trends/mentions?topic=...&country=...` fetches news articles and platform coverage for a trending topic. Requires `SERPAPI_KEY`.
+
+## Trends worker
+
+Scrapes Google Trends for each country and saves to MongoDB.
+
+```bash
+# One-time run
+python3 -m worker
+
+# Or use the wrapper (loads .env)
+./run-worker.sh
+```
+
+**Schedule every 24 hours** (cron):
+
+```bash
+# Make script executable
+chmod +x apps/api/run-worker.sh
+
+# Add to crontab (crontab -e)
+0 0 * * * /absolute/path/to/apps/api/run-worker.sh >> /var/log/hanfani-worker.log 2>&1
+```
+
+Runs at midnight daily. Change `0 0` to another hour (e.g. `0 6` for 6am).
+
+**Custom countries:**
+
+```bash
+TRENDS_COUNTRIES=US,GB,FR,CR python3 -m worker
+```
+
 ## Docker
 
 **Run API (runtime):**

--- a/apps/api/db.py
+++ b/apps/api/db.py
@@ -1,0 +1,27 @@
+"""MongoDB connection and database access."""
+
+from __future__ import annotations
+
+import os
+
+from pymongo import MongoClient
+from pymongo.collection import Collection
+from pymongo.database import Database
+
+MONGODB_URI = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
+DB_NAME = os.getenv("MONGODB_DB", "hanfani")
+
+
+def get_client() -> MongoClient:
+    """Get MongoDB client (creates new connection)."""
+    return MongoClient(MONGODB_URI)
+
+
+def get_db() -> Database:
+    """Get database instance."""
+    return get_client()[DB_NAME]
+
+
+def get_trends_collection() -> Collection:
+    """Get trends collection."""
+    return get_db()["trends"]

--- a/apps/api/db.py
+++ b/apps/api/db.py
@@ -10,11 +10,13 @@ from pymongo.database import Database
 
 MONGODB_URI = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
 DB_NAME = os.getenv("MONGODB_DB", "hanfani")
+# Fail fast if MongoDB unreachable (default 30s can cause frontend "signal timed out")
+MONGODB_TIMEOUT_MS = int(os.getenv("MONGODB_TIMEOUT_MS", "5000"))
 
 
 def get_client() -> MongoClient:
     """Get MongoDB client (creates new connection)."""
-    return MongoClient(MONGODB_URI)
+    return MongoClient(MONGODB_URI, serverSelectionTimeoutMS=MONGODB_TIMEOUT_MS)
 
 
 def get_db() -> Database:

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -3,8 +3,12 @@
 import os
 from datetime import datetime, timezone
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+
+from services.topic_mentions import fetch_topic_mentions
+from services.trends import get_trending_topics
+from services.trends_store import get_trends_from_db
 
 app = FastAPI(title="Hanfani AI API", version="0.1.0")
 
@@ -33,4 +37,75 @@ def status() -> dict:
         "service": "hanfani-api",
         "version": "0.1.0",
         "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@app.get("/trends")
+def trends(country: str = "US") -> dict:
+    """
+    Get top trending topics for a specific country.
+
+    Reads from MongoDB (populated by worker). Falls back to live fetch if no data.
+
+    Args:
+        country: ISO 3166-1 alpha-2 country code (e.g. US, GB, FR). Defaults to US.
+
+    Returns:
+        JSON with country, topics, source (api/fallback/db), and fetched_at.
+    """
+    code = country.strip().upper() if country else "US"
+    if len(code) != 2 or not code.isalpha():
+        raise HTTPException(status_code=400, detail=f"Invalid country code: {country}. Use ISO 3166-1 alpha-2 (e.g. US, GB).")
+
+    try:
+        doc = get_trends_from_db(code)
+        if doc and doc.topics:
+            return {
+                "country": doc.country,
+                "topics": doc.topics,
+                "source": "db",
+                "fetched_at": doc.fetched_at.isoformat(),
+            }
+    except Exception:
+        pass  # Fall through to live fetch
+
+    # No data in DB - fetch live (or fallback to mock)
+    try:
+        topics, source = get_trending_topics(country)
+        return {
+            "country": code,
+            "topics": topics,
+            "source": source,
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@app.get("/trends/mentions")
+def trend_mentions(topic: str, country: str = "US") -> dict:
+    """
+    Get news articles and platform mentions for a trending topic.
+
+    Requires SERPAPI_KEY for live data. Returns articles sorted by relevance
+    (position in Google News) and date.
+
+    Args:
+        topic: The trending topic to search for.
+        country: ISO 3166-1 alpha-2 country code (e.g. US, FR). Defaults to US.
+
+    Returns:
+        JSON with topic, country, mentions (list of articles/platforms).
+    """
+    if not topic or not topic.strip():
+        raise HTTPException(status_code=400, detail="Topic is required")
+
+    code = country.strip().upper() if country else "US"
+    if len(code) != 2 or not code.isalpha():
+        raise HTTPException(status_code=400, detail=f"Invalid country code: {country}")
+
+    mentions = fetch_topic_mentions(topic.strip(), code, limit=25)
+    return {
+        "topic": topic.strip(),
+        "country": code,
+        "mentions": mentions,
     }

--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -16,6 +16,6 @@ class TrendsDocument(BaseModel):
         default_factory=list,
         description="List of trend items: {title, search_volume?, started?}",
     )
-    source: Literal["api", "fallback"] = Field(default="fallback")
+    source: Literal["api", "fallback", "scraper", "serpapi", "db"] = Field(default="fallback")
     fetched_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)

--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -1,0 +1,21 @@
+"""Data models for Hanfani API."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class TrendsDocument(BaseModel):
+    """Trends document stored in MongoDB."""
+
+    country: str = Field(..., description="ISO 3166-1 alpha-2 country code")
+    topics: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="List of trend items: {title, search_volume?, started?}",
+    )
+    source: Literal["api", "fallback"] = Field(default="fallback")
+    fetched_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -14,7 +14,7 @@ testpaths = ["tests"]
 pythonpath = ["."]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-addopts = "-v --tb=short --cov=main --cov-report=xml:coverage.xml --cov-report=term-missing"
+addopts = "-v --tb=short --cov=main --cov=services --cov-report=xml:coverage.xml --cov-report=term-missing"
 filterwarnings = [
     "ignore::DeprecationWarning",
     "ignore::UserWarning",

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -11,6 +11,11 @@ starlette==0.52.1
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 uvicorn==0.40.0
+pytrends==4.9.2
+pandas>=2.0.0
+requests>=2.28.0
+playwright>=1.40.0
+pymongo>=4.6.0
 
 # Testing
 pytest==8.3.4

--- a/apps/api/run-worker.sh
+++ b/apps/api/run-worker.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Run the trends worker. Use with cron for daily runs:
+#   0 0 * * * /path/to/apps/api/run-worker.sh
+
+set -e
+cd "$(dirname "$0")"
+
+# Load .env if present
+if [ -f .env ]; then
+  set -a
+  source .env
+  set +a
+fi
+
+# Activate venv if it exists (ensures dependencies like pandas, playwright are available)
+if [ -d .venv ]; then
+  source .venv/bin/activate
+fi
+
+# Use python3 if python is not available
+if command -v python3 &>/dev/null; then
+  exec python3 -m worker
+else
+  exec python -m worker
+fi

--- a/apps/api/services/__init__.py
+++ b/apps/api/services/__init__.py
@@ -1,0 +1,1 @@
+"""Hanfani API services."""

--- a/apps/api/services/topic_mentions.py
+++ b/apps/api/services/topic_mentions.py
@@ -1,0 +1,153 @@
+"""Fetch news articles and social mentions for a trending topic."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, TypedDict
+
+import requests
+
+
+class MentionItem(TypedDict, total=False):
+    """A single mention (article, post, etc.) of a topic."""
+
+    title: str
+    source: str
+    source_type: str  # "news" | "social"
+    link: str
+    snippet: str
+    date: str
+    iso_date: str
+    authors: list[str]
+    thumbnail: str
+    position: int
+    platform: str  # e.g. "Twitter", "Reddit" when source_type=social
+
+
+def fetch_topic_mentions(topic: str, country: str, limit: int = 20) -> list[MentionItem]:
+    """
+    Fetch news articles and mentions for a topic in a country.
+
+    Uses SerpApi Google News when SERPAPI_KEY is set. Results are sorted by
+    relevance (position) then by date. Returns empty list on failure.
+
+    Args:
+        topic: The trending topic to search for.
+        country: ISO 3166-1 alpha-2 country code (e.g. US, FR).
+        limit: Max number of items to return (default 20).
+
+    Returns:
+        List of mention items with title, source, link, date, etc.
+    """
+    api_key = os.getenv("SERPAPI_KEY", "").strip()
+    if not api_key:
+        return []
+
+    try:
+        resp = requests.get(
+            "https://serpapi.com/search",
+            params={
+                "engine": "google_news",
+                "q": topic,
+                "gl": country.lower(),
+                "hl": _country_to_hl(country),
+                "api_key": api_key,
+                "so": 0,  # relevance
+            },
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data: dict[str, Any] = resp.json()
+    except Exception:
+        return []
+
+    items: list[MentionItem] = []
+    news_results = data.get("news_results") or []
+
+    for nr in news_results:
+        if len(items) >= limit:
+            break
+
+        # Handle nested structure (e.g. highlight, stories)
+        entry = nr
+        if "highlight" in nr:
+            entry = nr["highlight"]
+        elif "stories" in nr:
+            for story in nr.get("stories", [])[:5]:
+                item = _parse_news_entry(story, len(items) + 1)
+                if item and item not in items:
+                    items.append(item)
+            continue
+
+        item = _parse_news_entry(entry, len(items) + 1)
+        if item:
+            items.append(item)
+
+    # Sort by position (relevance) then by date (newest first)
+    def _sort_key(x: MentionItem) -> tuple:
+        pos = x.get("position", 999)
+        iso = x.get("iso_date") or ""
+        return (pos, "" if iso else "z")  # empty date last
+
+    items.sort(key=_sort_key)
+    return items[:limit]
+
+
+def _parse_news_entry(entry: dict[str, Any], default_pos: int) -> MentionItem | None:
+    """Parse a news_result entry into MentionItem."""
+    title = None
+    if "title" in entry:
+        title = str(entry["title"]).strip()
+    if not title and "snippet" in entry:
+        title = str(entry["snippet"])[:100].strip()
+    if not title:
+        return None
+
+    source_name = ""
+    authors: list[str] = []
+    if "source" in entry and isinstance(entry["source"], dict):
+        src = entry["source"]
+        source_name = str(src.get("name", "")).strip()
+        authors = src.get("authors") or []
+        if isinstance(authors, str):
+            authors = [authors] if authors else []
+
+    link = str(entry.get("link", "")).strip()
+    if not link:
+        return None
+
+    item: MentionItem = {
+        "title": title,
+        "source": source_name or "Unknown",
+        "source_type": "news",
+        "link": link,
+        "position": entry.get("position", default_pos),
+    }
+    if entry.get("snippet"):
+        item["snippet"] = str(entry["snippet"]).strip()
+    if entry.get("date"):
+        item["date"] = str(entry["date"])
+    if entry.get("iso_date"):
+        item["iso_date"] = str(entry["iso_date"])
+    if authors:
+        item["authors"] = authors
+    if entry.get("thumbnail"):
+        item["thumbnail"] = str(entry["thumbnail"])
+
+    return item
+
+
+def _country_to_hl(country: str) -> str:
+    """Map country code to language code for SerpApi."""
+    m: dict[str, str] = {
+        "FR": "fr",
+        "DE": "de",
+        "ES": "es",
+        "IT": "it",
+        "BR": "pt",
+        "JP": "ja",
+        "IN": "en",
+        "GB": "en",
+        "US": "en",
+    }
+    return m.get(country.upper(), "en")

--- a/apps/api/services/trends.py
+++ b/apps/api/services/trends.py
@@ -1,0 +1,181 @@
+"""Google Trends service for fetching top trending topics by country."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Protocol
+
+import pandas as pd
+import requests
+
+# Sample data when Google Trends API is unavailable (e.g. 404 from deprecated endpoints)
+_MOCK_TOPICS: list[str] = [
+    "AI developments",
+    "Climate summit",
+    "Tech earnings",
+    "Sports championship",
+    "Election updates",
+    "Space mission",
+    "Health breakthrough",
+    "Entertainment news",
+    "Economic indicators",
+    "Local events",
+]
+
+# trending_searches uses country names with underscores (pn param)
+_COUNTRY_TO_PN: dict[str, str] = {
+    "US": "united_states",
+    "GB": "united_kingdom",
+    "FR": "france",
+    "DE": "germany",
+    "IN": "india",
+    "JP": "japan",
+    "BR": "brazil",
+    "CA": "canada",
+    "AU": "australia",
+    "ES": "spain",
+    "IT": "italy",
+    "MX": "mexico",
+    "RU": "russia",
+    "KR": "south_korea",
+    "NL": "netherlands",
+    "PL": "poland",
+    "TR": "turkey",
+    "ID": "indonesia",
+    "SA": "saudi_arabia",
+    "CR": "costa_rica",
+}
+
+
+class TrendsClient(Protocol):
+    """Protocol for a Google Trends client (pytrends-compatible)."""
+
+    def trending_searches(self, pn: str) -> pd.DataFrame:
+        """Fetch trending searches for a country (hottrends endpoint)."""
+        ...
+
+    def realtime_trending_searches(self, pn: str, cat: str = "all", count: int = 300) -> pd.DataFrame:
+        """Fetch realtime trending searches for a country."""
+        ...
+
+
+def get_trending_topics(country: str, client: object | None = None) -> tuple[list[dict[str, Any]], str]:
+    """
+    Get the top trending topics for a specific country.
+
+    Tries trending_searches (hottrends) first, then realtime_trending_searches.
+    Falls back to sample data when Google's API is unavailable.
+
+    Args:
+        country: ISO 3166-1 alpha-2 country code (e.g. US, GB, FR).
+        client: Optional trends client. If None, uses pytrends TrendReq.
+
+    Returns:
+        Tuple of (topics list of dicts with title/search_volume/started, source).
+
+    Raises:
+        ValueError: If country code is invalid or empty.
+    """
+    if not country or not country.strip():
+        raise ValueError("Country code is required")
+
+    code = country.strip().upper()
+    if len(code) != 2 or not code.isalpha():
+        raise ValueError(f"Invalid country code: {country}. Use ISO 3166-1 alpha-2 (e.g. US, GB).")
+
+    def _to_items(titles: list[str]) -> list[dict[str, Any]]:
+        return [{"title": t} for t in titles]
+
+    if os.getenv("TRENDS_USE_MOCK", "").lower() in ("1", "true", "yes"):
+        return (_to_items(_MOCK_TOPICS.copy()), "fallback")
+
+    # Scrape: no API key, uses Playwright to scrape trends.google.com/trending (primary)
+    if os.getenv("TRENDS_USE_SCRAPER", "true").lower() in ("1", "true", "yes"):
+        try:
+            from services.trends_scraper import scrape_trending_topics
+
+            topics = scrape_trending_topics(code)
+            if topics:
+                return (topics, "scraper")
+        except Exception:
+            pass
+
+    # SerpApi: optional, requires SERPAPI_KEY (100 free searches/month)
+    api_key = os.getenv("SERPAPI_KEY", "").strip()
+    if api_key:
+        titles = _fetch_via_serpapi(code, api_key)
+        if titles:
+            return (_to_items(titles), "serpapi")
+
+    if client is None:
+        from pytrends.request import TrendReq
+
+        client = TrendReq(hl="en-US", tz=360)
+
+    pn = _COUNTRY_TO_PN.get(code, "united_states")
+
+    # Try trending_searches first (hottrends/visualize - different endpoint)
+    try:
+        df = client.trending_searches(pn=pn)
+        if not df.empty:
+            titles = _extract_titles(df)
+            if titles:
+                return (_to_items(titles), "api")
+    except Exception:
+        pass
+
+    # Fallback: realtime_trending_searches
+    try:
+        df = client.realtime_trending_searches(pn=code)
+        if not df.empty:
+            titles = _extract_titles(df)
+            if titles:
+                return (_to_items(titles), "api")
+    except Exception:
+        pass
+
+    # Google API unavailable - return sample data so the app works
+    return (_to_items(_MOCK_TOPICS.copy()), "fallback")
+
+
+def _fetch_via_serpapi(country: str, api_key: str) -> list[str]:
+    """Fetch trending searches via SerpApi (https://serpapi.com/google-trends-trending-now)."""
+    try:
+        resp = requests.get(
+            "https://serpapi.com/search",
+            params={
+                "engine": "google_trends_trending_now",
+                "geo": country,
+                "api_key": api_key,
+            },
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data: dict[str, Any] = resp.json()
+        items = data.get("trending_searches", [])
+        if not isinstance(items, list):
+            return []
+        topics = []
+        for item in items:
+            if isinstance(item, dict) and "query" in item:
+                q = str(item["query"]).strip()
+                if q:
+                    topics.append(q)
+        return topics
+    except Exception:
+        return []
+
+
+def _extract_titles(df: pd.DataFrame) -> list[str]:
+    """Extract topic titles from a trends DataFrame."""
+    if "title" in df.columns:
+        titles = df["title"].astype(str).str.strip()
+    elif "entityNames" in df.columns:
+        col = df["entityNames"]
+        # entityNames can be list or str
+        titles = col.apply(
+            lambda x: ", ".join(x) if isinstance(x, list) else str(x)
+        ).str.strip()
+    else:
+        titles = df.iloc[:, -1].astype(str).str.strip()
+    return titles.dropna().replace("", pd.NA).dropna().unique().tolist()

--- a/apps/api/services/trends_scraper.py
+++ b/apps/api/services/trends_scraper.py
@@ -1,0 +1,199 @@
+"""Scrape Google Trends trending page (no API key required)."""
+
+from __future__ import annotations
+
+import csv
+import tempfile
+from pathlib import Path
+from typing import TypedDict
+
+LIMIT = 25
+
+# Use locale-specific domain when available (e.g. trends.google.fr for FR)
+_COUNTRY_DOMAIN = {"FR": "trends.google.fr", "DE": "trends.google.de", "GB": "trends.google.co.uk"}
+
+
+class TrendItem(TypedDict, total=False):
+    """A single trend with optional metadata."""
+
+    title: str
+    search_volume: str
+    started: str
+
+
+def scrape_trending_topics(country: str) -> list[TrendItem]:
+    """
+    Scrape the first 25 trending topics from Google Trends for a country.
+
+    Uses Playwright to load the page and either:
+    - Clicks the CSV download button and parses the file, or
+    - Extracts trend titles from the DOM.
+
+    Args:
+        country: ISO 3166-1 alpha-2 country code (e.g. US, FR).
+
+    Returns:
+        List of up to 25 trend items with title, search_volume, started.
+    """
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        return []
+
+    domain = _COUNTRY_DOMAIN.get(country, "trends.google.com")
+    url = f"https://{domain}/trending?geo={country}"
+    topics: list[TrendItem] = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(
+            accept_downloads=True,
+            user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        )
+        page = context.new_page()
+
+        try:
+            page.goto(url, wait_until="networkidle", timeout=30000)
+            page.wait_for_timeout(4000)  # Allow dynamic content to render
+
+            # Try CSV download first (Export -> Download CSV / Télécharger au format CSV)
+            export_btn = page.locator('button:has-text("Export"), button:has-text("Exporter")').first
+            if export_btn.is_visible(timeout=2000):
+                try:
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        download_path = Path(tmpdir) / "trends.csv"
+                        with page.expect_download(timeout=15000) as download_info:
+                            export_btn.click()
+                            page.wait_for_timeout(1200)
+                            csv_btn = page.get_by_role("menuitem").filter(has_text="CSV").first
+                            if not csv_btn.is_visible(timeout=2000):
+                                csv_btn = page.locator('a:has-text("CSV"), [role="menuitem"]:has-text("CSV")').first
+                            if csv_btn.is_visible(timeout=2000):
+                                csv_btn.click()
+                        download = download_info.value
+                        download.save_as(download_path)
+                        topics = _parse_trends_csv(download_path)
+                except Exception:
+                    pass
+
+            # Fallback: extract from DOM
+            if not topics:
+                # Scroll to load lazy-rendered rows (table often virtualizes)
+                try:
+                    page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+                    page.wait_for_timeout(1500)
+                    page.evaluate("window.scrollTo(0, 0)")
+                    page.wait_for_timeout(500)
+                except Exception:
+                    pass
+                topics = _extract_from_dom(page)
+
+            browser.close()
+        except Exception:
+            try:
+                browser.close()
+            except Exception:
+                pass
+
+    return topics[:LIMIT]
+
+
+# Header-like values to skip (exact or start of first column)
+_CSV_SKIP = (
+    "trend", "tendances", "topic", "query", "search", "recherche",
+    "volume", "started", "démarrée", "composition", "état",
+)
+
+
+def _parse_trends_csv(path: Path) -> list[TrendItem]:
+    """Parse trend items from downloaded CSV. Columns: title, search_volume, started."""
+    topics: list[TrendItem] = []
+    seen: set[str] = set()
+    try:
+        with open(path, encoding="utf-8-sig", errors="replace") as f:
+            reader = csv.reader(f)
+            for row in reader:
+                if not row or not row[0]:
+                    continue
+                val = str(row[0]).strip()
+                if not val or val.startswith("#"):
+                    continue
+                low = val.lower()
+                if low in _CSV_SKIP or any(low.startswith(s) for s in _CSV_SKIP):
+                    continue
+                if len(val) > 1 and val not in seen:
+                    seen.add(val)
+                    item: TrendItem = {"title": val}
+                    if len(row) > 1 and row[1]:
+                        item["search_volume"] = str(row[1]).strip()
+                    if len(row) > 2 and row[2]:
+                        item["started"] = str(row[2]).strip()
+                    topics.append(item)
+                    if len(topics) >= LIMIT:
+                        break
+    except Exception:
+        pass
+    return topics
+
+
+def _extract_from_dom(page) -> list[TrendItem]:
+    """Extract trend items from page DOM. Table columns: title, search_volume, started."""
+    skip = {
+        "trends", "tendances", "export", "exporter", "search", "recherche",
+        "trend", "volume", "started", "démarrée", "tendances de recherche",
+        "search trends", "composition", "état",
+    }
+    best: list[TrendItem] = []
+    seen: set[str] = set()
+
+    def _add(title: str, volume: str = "", started: str = "") -> None:
+        if not title or title.lower() in skip or title in seen or not (2 < len(title) < 200):
+            return
+        seen.add(title)
+        item: TrendItem = {"title": title}
+        if volume:
+            item["search_volume"] = volume
+        if started:
+            item["started"] = started
+        best.append(item)
+
+    try:
+        # 1. Rows via get_by_role - extract all columns
+        rows = page.get_by_role("row").all()
+        for row in rows[1:]:  # Skip header row
+            try:
+                cells = row.locator("td").all()
+                if len(cells) >= 1:
+                    title = cells[0].inner_text().strip().split("\n")[0].strip()
+                    volume = cells[1].inner_text().strip().split("\n")[0].strip() if len(cells) > 1 else ""
+                    started = cells[2].inner_text().strip().split("\n")[0].strip() if len(cells) > 2 else ""
+                    _add(title, volume, started)
+            except Exception:
+                pass
+            if len(best) >= LIMIT:
+                break
+
+        # 2. Fallback: first column only (no volume/started)
+        if len(best) < 5:
+            for sel in [
+                "tr[role='row'] td:first-child",
+                "[role='row'] td:first-child",
+                "table td:first-child",
+                "a[href*='/trends/explore']",
+            ]:
+                try:
+                    for el in page.locator(sel).all()[:LIMIT * 2]:
+                        try:
+                            raw = el.inner_text().strip()
+                            title = raw.split("\n")[0].strip() if raw else ""
+                            _add(title)
+                        except Exception:
+                            continue
+                    if len(best) >= LIMIT:
+                        break
+                except Exception:
+                    continue
+    except Exception:
+        pass
+
+    return best[:LIMIT]

--- a/apps/api/services/trends_store.py
+++ b/apps/api/services/trends_store.py
@@ -1,0 +1,63 @@
+"""Trends storage and retrieval from MongoDB."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from db import get_trends_collection
+from models import TrendsDocument
+
+
+def save_trends(country: str, topics: list[dict] | list[str], source: str = "api") -> None:
+    """
+    Save or update trends for a country in MongoDB.
+
+    Uses upsert: replaces existing document for the country.
+    topics: list of dicts {title, search_volume?, started?} or list of strings (legacy).
+    """
+    now = datetime.now(timezone.utc)
+    # Normalize: convert list[str] to list[dict]
+    normalized = [
+        t if isinstance(t, dict) else {"title": str(t)}
+        for t in topics
+    ]
+    doc = {
+        "country": country.upper(),
+        "topics": normalized,
+        "source": source,
+        "fetched_at": now,
+        "updated_at": now,
+    }
+    coll = get_trends_collection()
+    coll.update_one(
+        {"country": country.upper()},
+        {"$set": doc},
+        upsert=True,
+    )
+
+
+def get_trends_from_db(country: str) -> TrendsDocument | None:
+    """
+    Get the latest trends for a country from MongoDB.
+
+    Returns None if no document exists for the country.
+    """
+    coll = get_trends_collection()
+    doc = coll.find_one({"country": country.upper()})
+    if doc is None:
+        return None
+    raw_topics = doc.get("topics", [])
+    # Normalize: legacy list[str] -> list[dict]
+    topics = [
+        t if isinstance(t, dict) else {"title": str(t)}
+        for t in raw_topics
+    ]
+    fetched = doc.get("fetched_at") or doc.get("updated_at")
+    updated = doc.get("updated_at") or doc.get("fetched_at")
+    return TrendsDocument(
+        country=doc["country"],
+        topics=topics,
+        source=doc.get("source", "fallback"),
+        fetched_at=fetched,
+        updated_at=updated,
+    )

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,12 +1,23 @@
 """Pytest fixtures for Hanfani API tests."""
 
+from datetime import datetime, timezone
+from unittest.mock import patch
+
 import pytest
 from fastapi.testclient import TestClient
 
 from main import app
+from models import TrendsDocument
 
 
 @pytest.fixture
 def client() -> TestClient:
     """Create a test client for the FastAPI application."""
     return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def mock_db_empty():
+    """Mock get_trends_from_db to return None (no DB data) so tests use live fetch path."""
+    with patch("main.get_trends_from_db", return_value=None):
+        yield

--- a/apps/api/tests/test_topic_mentions.py
+++ b/apps/api/tests/test_topic_mentions.py
@@ -1,0 +1,42 @@
+"""Tests for the topic mentions API endpoint."""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def test_mentions_returns_articles(client: TestClient) -> None:
+    """GET /trends/mentions returns topic, country, and mentions list."""
+    with patch("main.fetch_topic_mentions") as mock_fetch:
+        mock_fetch.return_value = [
+            {
+                "title": "Article about AI",
+                "source": "TechCrunch",
+                "link": "https://example.com/1",
+                "date": "2 hours ago",
+            },
+        ]
+        response = client.get("/trends/mentions?topic=AI&country=US")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["topic"] == "AI"
+    assert data["country"] == "US"
+    assert len(data["mentions"]) == 1
+    assert data["mentions"][0]["title"] == "Article about AI"
+    assert data["mentions"][0]["source"] == "TechCrunch"
+    mock_fetch.assert_called_once_with("AI", "US", limit=25)
+
+
+def test_mentions_missing_topic_returns_400(client: TestClient) -> None:
+    """GET /trends/mentions without topic returns 400."""
+    response = client.get("/trends/mentions?country=US")
+    assert response.status_code == 422  # FastAPI returns 422 for missing required param
+
+
+def test_mentions_invalid_country_returns_400(client: TestClient) -> None:
+    """GET /trends/mentions with invalid country returns 400."""
+    response = client.get("/trends/mentions?topic=AI&country=XYZ")
+    assert response.status_code == 400
+    assert "Invalid" in response.json()["detail"]

--- a/apps/api/tests/test_topic_mentions.py
+++ b/apps/api/tests/test_topic_mentions.py
@@ -1,9 +1,13 @@
-"""Tests for the topic mentions API endpoint."""
+"""Tests for the topic mentions API endpoint and service."""
 
+import os
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
+
+
+# --- API endpoint tests ---
 
 
 def test_mentions_returns_articles(client: TestClient) -> None:
@@ -40,3 +44,135 @@ def test_mentions_invalid_country_returns_400(client: TestClient) -> None:
     response = client.get("/trends/mentions?topic=AI&country=XYZ")
     assert response.status_code == 400
     assert "Invalid" in response.json()["detail"]
+
+
+# --- Service unit tests ---
+
+
+def test_parse_news_entry_minimal() -> None:
+    """_parse_news_entry returns item with title and link."""
+    from services.topic_mentions import _parse_news_entry
+
+    entry = {"title": "Test Article", "link": "https://example.com/1"}
+    result = _parse_news_entry(entry, 1)
+    assert result is not None
+    assert result["title"] == "Test Article"
+    assert result["source"] == "Unknown"
+    assert result["link"] == "https://example.com/1"
+    assert result["source_type"] == "news"
+    assert result["position"] == 1
+
+
+def test_parse_news_entry_full() -> None:
+    """_parse_news_entry includes optional fields when present."""
+    from services.topic_mentions import _parse_news_entry
+
+    entry = {
+        "title": "Full Article",
+        "link": "https://example.com/2",
+        "source": {"name": "TechCrunch", "authors": ["Alice", "Bob"]},
+        "snippet": "A brief summary.",
+        "date": "2 hours ago",
+        "iso_date": "2024-01-15T10:00:00Z",
+        "thumbnail": "https://example.com/img.jpg",
+    }
+    result = _parse_news_entry(entry, 5)
+    assert result is not None
+    assert result["title"] == "Full Article"
+    assert result["source"] == "TechCrunch"
+    assert result["snippet"] == "A brief summary."
+    assert result["date"] == "2 hours ago"
+    assert result["iso_date"] == "2024-01-15T10:00:00Z"
+    assert result["authors"] == ["Alice", "Bob"]
+    assert result["thumbnail"] == "https://example.com/img.jpg"
+
+
+def test_parse_news_entry_no_title_uses_snippet() -> None:
+    """_parse_news_entry uses snippet as title when title missing."""
+    from services.topic_mentions import _parse_news_entry
+
+    entry = {"snippet": "Fallback title here", "link": "https://example.com/3"}
+    result = _parse_news_entry(entry, 1)
+    assert result is not None
+    assert result["title"] == "Fallback title here"
+
+
+def test_parse_news_entry_no_link_returns_none() -> None:
+    """_parse_news_entry returns None when link is empty."""
+    from services.topic_mentions import _parse_news_entry
+
+    entry = {"title": "No Link", "link": ""}
+    assert _parse_news_entry(entry, 1) is None
+
+
+def test_parse_news_entry_no_title_or_snippet_returns_none() -> None:
+    """_parse_news_entry returns None when neither title nor snippet."""
+    from services.topic_mentions import _parse_news_entry
+
+    entry = {"link": "https://example.com"}
+    assert _parse_news_entry(entry, 1) is None
+
+
+def test_country_to_hl() -> None:
+    """_country_to_hl maps country codes to language codes."""
+    from services.topic_mentions import _country_to_hl
+
+    assert _country_to_hl("FR") == "fr"
+    assert _country_to_hl("DE") == "de"
+    assert _country_to_hl("JP") == "ja"
+    assert _country_to_hl("US") == "en"
+    assert _country_to_hl("GB") == "en"
+    assert _country_to_hl("XX") == "en"  # default
+
+
+def test_fetch_topic_mentions_no_api_key() -> None:
+    """fetch_topic_mentions returns empty list when SERPAPI_KEY not set."""
+    from services.topic_mentions import fetch_topic_mentions
+
+    with patch.dict(os.environ, {"SERPAPI_KEY": ""}, clear=False):
+        result = fetch_topic_mentions("AI", "US")
+    assert result == []
+
+
+def test_fetch_topic_mentions_success() -> None:
+    """fetch_topic_mentions returns parsed items on successful API response."""
+    from unittest.mock import MagicMock
+
+    from services.topic_mentions import fetch_topic_mentions
+
+    mock_response = {
+        "news_results": [
+            {
+                "title": "AI News",
+                "link": "https://example.com/ai",
+                "source": {"name": "TechNews"},
+                "position": 1,
+            },
+        ]
+    }
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = mock_response
+
+    with patch.dict(os.environ, {"SERPAPI_KEY": "test-key"}, clear=False):
+        with patch("services.topic_mentions.requests.get") as mock_get:
+            mock_get.return_value = mock_resp
+
+            result = fetch_topic_mentions("AI", "US", limit=5)
+
+    assert len(result) == 1
+    assert result[0]["title"] == "AI News"
+    assert result[0]["source"] == "TechNews"
+
+
+def test_fetch_topic_mentions_api_error_returns_empty() -> None:
+    """fetch_topic_mentions returns empty list on API error."""
+    from services.topic_mentions import fetch_topic_mentions
+
+    with patch.dict(os.environ, {"SERPAPI_KEY": "test-key"}, clear=False):
+        with patch("services.topic_mentions.requests.get") as mock_get:
+            mock_get.side_effect = Exception("Network error")
+
+            result = fetch_topic_mentions("AI", "US")
+
+    assert result == []

--- a/apps/api/tests/test_trends.py
+++ b/apps/api/tests/test_trends.py
@@ -1,0 +1,192 @@
+"""Tests for the Google Trends API endpoint and service."""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from models import TrendsDocument
+
+
+def test_trends_returns_topics_for_country(client: TestClient) -> None:
+    """GET /trends?country=US returns country and list of topics (with optional metadata)."""
+    with patch(
+        "main.get_trending_topics",
+        return_value=(
+            [
+                {"title": "Topic A", "search_volume": "1M+", "started": "2h ago"},
+                {"title": "Topic B"},
+                {"title": "Topic C"},
+            ],
+            "scraper",
+        ),
+    ):
+        response = client.get("/trends?country=US")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["country"] == "US"
+    assert data["topics"][0]["title"] == "Topic A"
+    assert data["topics"][0]["search_volume"] == "1M+"
+    assert data["topics"][0]["started"] == "2h ago"
+    assert data["topics"][1]["title"] == "Topic B"
+    assert data["source"] == "scraper"
+
+
+def test_trends_defaults_to_us(client: TestClient) -> None:
+    """GET /trends without country defaults to US."""
+    with patch(
+        "main.get_trending_topics",
+        return_value=([{"title": "Default Topic"}], "scraper"),
+    ):
+        response = client.get("/trends")
+
+    assert response.status_code == 200
+    assert response.json()["country"] == "US"
+
+
+def test_trends_normalizes_country_code(client: TestClient) -> None:
+    """GET /trends normalizes country code to uppercase."""
+    with patch(
+        "main.get_trending_topics",
+        return_value=([{"title": "Topic"}], "scraper"),
+    ) as mock_get:
+        response = client.get("/trends?country=gb")
+
+    assert response.status_code == 200
+    assert response.json()["country"] == "GB"
+    mock_get.assert_called_once_with("gb")
+
+
+def test_trends_invalid_country_returns_400(client: TestClient) -> None:
+    """GET /trends with invalid country code returns 400."""
+    with patch(
+        "main.get_trending_topics",
+        side_effect=ValueError("Invalid country code: XYZ. Use ISO 3166-1 alpha-2 (e.g. US, GB)."),
+    ):
+        response = client.get("/trends?country=XYZ")
+
+    assert response.status_code == 400
+    assert "Invalid" in response.json()["detail"]
+
+
+def test_trends_empty_country_returns_400(client: TestClient) -> None:
+    """GET /trends with empty country returns 400."""
+    with patch(
+        "main.get_trending_topics",
+        side_effect=ValueError("Country code is required"),
+    ):
+        response = client.get("/trends?country=")
+
+    assert response.status_code == 400
+
+
+def test_trends_api_failure_returns_fallback(client: TestClient) -> None:
+    """GET /trends when Google Trends API fails returns fallback data, not 502."""
+    with patch(
+        "main.get_trending_topics",
+        return_value=([{"title": "Fallback 1"}, {"title": "Fallback 2"}], "fallback"),
+    ):
+        response = client.get("/trends?country=US")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [t["title"] for t in data["topics"]] == ["Fallback 1", "Fallback 2"]
+    assert data["source"] == "fallback"
+
+
+def test_trends_from_db(client: TestClient) -> None:
+    """GET /trends returns data from MongoDB when available."""
+    doc = TrendsDocument(
+        country="US",
+        topics=[
+            {"title": "DB Topic 1", "search_volume": "500K"},
+            {"title": "DB Topic 2"},
+        ],
+        source="api",
+        fetched_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    with patch("main.get_trends_from_db", return_value=doc):
+        response = client.get("/trends?country=US")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["country"] == "US"
+    assert data["topics"][0]["title"] == "DB Topic 1"
+    assert data["topics"][0]["search_volume"] == "500K"
+    assert data["source"] == "db"
+    assert "fetched_at" in data
+
+
+def test_trends_empty_result(client: TestClient) -> None:
+    """GET /trends returns empty list when no trends available."""
+    with patch(
+        "main.get_trending_topics",
+        return_value=([], "scraper"),
+    ):
+        response = client.get("/trends?country=FR")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["country"] == "FR"
+    assert data["topics"] == []
+    assert data["source"] == "scraper"
+
+
+# --- Service layer tests ---
+
+
+def test_get_trending_topics_returns_list() -> None:
+    """get_trending_topics returns list of trend dicts from API."""
+    from services.trends import get_trending_topics
+
+    mock_df = pd.DataFrame({0: ["Trend 1", "Trend 2"]})
+
+    class MockClient:
+        def trending_searches(self, pn: str) -> pd.DataFrame:
+            return mock_df
+
+        def realtime_trending_searches(self, pn: str, cat: str = "all", count: int = 300) -> pd.DataFrame:
+            return pd.DataFrame()
+
+    topics, source = get_trending_topics("US", client=MockClient())
+    assert [t["title"] for t in topics] == ["Trend 1", "Trend 2"]
+    assert source == "api"
+
+
+def test_get_trending_topics_fallback_when_api_fails() -> None:
+    """get_trending_topics returns mock data when both endpoints fail."""
+    from services.trends import get_trending_topics
+
+    class MockClient:
+        def trending_searches(self, pn: str) -> pd.DataFrame:
+            raise Exception("404")
+
+        def realtime_trending_searches(self, pn: str, cat: str = "all", count: int = 300) -> pd.DataFrame:
+            raise Exception("404")
+
+    topics, source = get_trending_topics("GB", client=MockClient())
+    assert len(topics) > 0
+    assert source == "fallback"
+
+
+def test_get_trending_topics_invalid_country_empty() -> None:
+    """get_trending_topics raises ValueError for empty country."""
+    from services.trends import get_trending_topics
+
+    with pytest.raises(ValueError, match="Country code is required"):
+        get_trending_topics("", client=object())  # type: ignore
+
+
+def test_get_trending_topics_invalid_country_format() -> None:
+    """get_trending_topics raises ValueError for invalid country format."""
+    from services.trends import get_trending_topics
+
+    with pytest.raises(ValueError, match="Invalid country code"):
+        get_trending_topics("USA", client=object())  # type: ignore
+
+    with pytest.raises(ValueError, match="Invalid country code"):
+        get_trending_topics("1", client=object())  # type: ignore

--- a/apps/api/tests/test_trends.py
+++ b/apps/api/tests/test_trends.py
@@ -1,7 +1,8 @@
 """Tests for the Google Trends API endpoint and service."""
 
+import os
 from datetime import datetime, timezone
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -11,18 +12,19 @@ from models import TrendsDocument
 
 
 def test_trends_returns_topics_for_country(client: TestClient) -> None:
-    """GET /trends?country=US returns country and list of topics (with optional metadata)."""
-    with patch(
-        "main.get_trending_topics",
-        return_value=(
-            [
-                {"title": "Topic A", "search_volume": "1M+", "started": "2h ago"},
-                {"title": "Topic B"},
-                {"title": "Topic C"},
-            ],
-            "scraper",
-        ),
-    ):
+    """GET /trends?country=US returns country and list of topics from DB."""
+    doc = TrendsDocument(
+        country="US",
+        topics=[
+            {"title": "Topic A", "search_volume": "1M+", "started": "2h ago"},
+            {"title": "Topic B"},
+            {"title": "Topic C"},
+        ],
+        source="api",
+        fetched_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    with patch("main.get_trends_from_db", return_value=doc):
         response = client.get("/trends?country=US")
 
     assert response.status_code == 200
@@ -32,15 +34,19 @@ def test_trends_returns_topics_for_country(client: TestClient) -> None:
     assert data["topics"][0]["search_volume"] == "1M+"
     assert data["topics"][0]["started"] == "2h ago"
     assert data["topics"][1]["title"] == "Topic B"
-    assert data["source"] == "scraper"
+    assert data["source"] == "db"
 
 
 def test_trends_defaults_to_us(client: TestClient) -> None:
     """GET /trends without country defaults to US."""
-    with patch(
-        "main.get_trending_topics",
-        return_value=([{"title": "Default Topic"}], "scraper"),
-    ):
+    doc = TrendsDocument(
+        country="US",
+        topics=[{"title": "Default Topic"}],
+        source="api",
+        fetched_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    with patch("main.get_trends_from_db", return_value=doc):
         response = client.get("/trends")
 
     assert response.status_code == 200
@@ -49,51 +55,42 @@ def test_trends_defaults_to_us(client: TestClient) -> None:
 
 def test_trends_normalizes_country_code(client: TestClient) -> None:
     """GET /trends normalizes country code to uppercase."""
-    with patch(
-        "main.get_trending_topics",
-        return_value=([{"title": "Topic"}], "scraper"),
-    ) as mock_get:
+    doc = TrendsDocument(
+        country="GB",
+        topics=[{"title": "Topic"}],
+        source="api",
+        fetched_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    with patch("main.get_trends_from_db", return_value=doc) as mock_get:
         response = client.get("/trends?country=gb")
 
     assert response.status_code == 200
     assert response.json()["country"] == "GB"
-    mock_get.assert_called_once_with("gb")
+    mock_get.assert_called_once_with("GB")
 
 
 def test_trends_invalid_country_returns_400(client: TestClient) -> None:
     """GET /trends with invalid country code returns 400."""
-    with patch(
-        "main.get_trending_topics",
-        side_effect=ValueError("Invalid country code: XYZ. Use ISO 3166-1 alpha-2 (e.g. US, GB)."),
-    ):
-        response = client.get("/trends?country=XYZ")
-
+    response = client.get("/trends?country=XYZ")
     assert response.status_code == 400
     assert "Invalid" in response.json()["detail"]
 
 
 def test_trends_empty_country_returns_400(client: TestClient) -> None:
     """GET /trends with empty country returns 400."""
-    with patch(
-        "main.get_trending_topics",
-        side_effect=ValueError("Country code is required"),
-    ):
-        response = client.get("/trends?country=")
-
+    response = client.get("/trends?country=")
     assert response.status_code == 400
 
 
-def test_trends_api_failure_returns_fallback(client: TestClient) -> None:
-    """GET /trends when Google Trends API fails returns fallback data, not 502."""
-    with patch(
-        "main.get_trending_topics",
-        return_value=([{"title": "Fallback 1"}, {"title": "Fallback 2"}], "fallback"),
-    ):
+def test_trends_db_unreachable_returns_empty_fallback(client: TestClient) -> None:
+    """GET /trends when DB unreachable returns empty list immediately, no timeout."""
+    with patch("main.get_trends_from_db", side_effect=Exception("Connection refused")):
         response = client.get("/trends?country=US")
 
     assert response.status_code == 200
     data = response.json()
-    assert [t["title"] for t in data["topics"]] == ["Fallback 1", "Fallback 2"]
+    assert data["topics"] == []
     assert data["source"] == "fallback"
 
 
@@ -122,18 +119,15 @@ def test_trends_from_db(client: TestClient) -> None:
 
 
 def test_trends_empty_result(client: TestClient) -> None:
-    """GET /trends returns empty list when no trends available."""
-    with patch(
-        "main.get_trending_topics",
-        return_value=([], "scraper"),
-    ):
+    """GET /trends returns empty list when DB has no data for country."""
+    with patch("main.get_trends_from_db", return_value=None):
         response = client.get("/trends?country=FR")
 
     assert response.status_code == 200
     data = response.json()
     assert data["country"] == "FR"
     assert data["topics"] == []
-    assert data["source"] == "scraper"
+    assert data["source"] == "fallback"
 
 
 # --- Service layer tests ---
@@ -152,7 +146,12 @@ def test_get_trending_topics_returns_list() -> None:
         def realtime_trending_searches(self, pn: str, cat: str = "all", count: int = 300) -> pd.DataFrame:
             return pd.DataFrame()
 
-    topics, source = get_trending_topics("US", client=MockClient())
+    with patch.dict(
+        os.environ,
+        {"TRENDS_USE_SCRAPER": "false", "SERPAPI_KEY": ""},
+        clear=False,
+    ):
+        topics, source = get_trending_topics("US", client=MockClient())
     assert [t["title"] for t in topics] == ["Trend 1", "Trend 2"]
     assert source == "api"
 
@@ -168,7 +167,12 @@ def test_get_trending_topics_fallback_when_api_fails() -> None:
         def realtime_trending_searches(self, pn: str, cat: str = "all", count: int = 300) -> pd.DataFrame:
             raise Exception("404")
 
-    topics, source = get_trending_topics("GB", client=MockClient())
+    with patch.dict(
+        os.environ,
+        {"TRENDS_USE_SCRAPER": "false", "SERPAPI_KEY": ""},
+        clear=False,
+    ):
+        topics, source = get_trending_topics("GB", client=MockClient())
     assert len(topics) > 0
     assert source == "fallback"
 
@@ -177,16 +181,113 @@ def test_get_trending_topics_invalid_country_empty() -> None:
     """get_trending_topics raises ValueError for empty country."""
     from services.trends import get_trending_topics
 
-    with pytest.raises(ValueError, match="Country code is required"):
-        get_trending_topics("", client=object())  # type: ignore
+    with patch.dict(os.environ, {"TRENDS_USE_SCRAPER": "false"}, clear=False):
+        with pytest.raises(ValueError, match="Country code is required"):
+            get_trending_topics("", client=object())  # type: ignore
 
 
 def test_get_trending_topics_invalid_country_format() -> None:
     """get_trending_topics raises ValueError for invalid country format."""
     from services.trends import get_trending_topics
 
-    with pytest.raises(ValueError, match="Invalid country code"):
-        get_trending_topics("USA", client=object())  # type: ignore
+    with patch.dict(os.environ, {"TRENDS_USE_SCRAPER": "false"}, clear=False):
+        with pytest.raises(ValueError, match="Invalid country code"):
+            get_trending_topics("USA", client=object())  # type: ignore
 
-    with pytest.raises(ValueError, match="Invalid country code"):
-        get_trending_topics("1", client=object())  # type: ignore
+        with pytest.raises(ValueError, match="Invalid country code"):
+            get_trending_topics("1", client=object())  # type: ignore
+
+
+def test_get_trending_topics_use_mock() -> None:
+    """get_trending_topics returns mock data when TRENDS_USE_MOCK is set."""
+    from services.trends import get_trending_topics
+
+    with patch.dict(os.environ, {"TRENDS_USE_MOCK": "true"}, clear=False):
+        topics, source = get_trending_topics("US", client=object())  # type: ignore
+
+    assert len(topics) > 0
+    assert all("title" in t for t in topics)
+    assert source == "fallback"
+
+
+def test_get_trending_topics_serpapi_when_scraper_fails() -> None:
+    """get_trending_topics uses SerpApi when scraper fails and key is set."""
+    from services.trends import get_trending_topics
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "trending_searches": [
+            {"query": "SerpApi Topic 1"},
+            {"query": "SerpApi Topic 2"},
+        ]
+    }
+
+    with patch.dict(os.environ, {"SERPAPI_KEY": "test-key"}, clear=False):
+        with patch("services.trends_scraper.scrape_trending_topics") as mock_scrape:
+            mock_scrape.return_value = []  # scraper returns empty
+            with patch("services.trends.requests.get") as mock_get:
+                mock_get.return_value = mock_resp
+
+                topics, source = get_trending_topics("US")
+
+    assert [t["title"] for t in topics] == ["SerpApi Topic 1", "SerpApi Topic 2"]
+    assert source == "serpapi"
+
+
+def test_extract_titles_from_title_column() -> None:
+    """_extract_titles uses 'title' column when present."""
+    from services.trends import _extract_titles
+
+    df = pd.DataFrame({"title": ["A", "B", "A"]})
+    assert _extract_titles(df) == ["A", "B"]
+
+
+def test_extract_titles_from_entity_names() -> None:
+    """_extract_titles uses entityNames (list or str) when present."""
+    from services.trends import _extract_titles
+
+    df = pd.DataFrame({"entityNames": [["X", "Y"], "Z"]})
+    result = _extract_titles(df)
+    assert "X, Y" in result
+    assert "Z" in result
+
+
+def test_extract_titles_fallback_last_column() -> None:
+    """_extract_titles uses last column when neither title nor entityNames."""
+    from services.trends import _extract_titles
+
+    df = pd.DataFrame({"a": [1, 2], "b": ["P", "Q"]})
+    assert _extract_titles(df) == ["P", "Q"]
+
+
+def test_fetch_via_serpapi_success() -> None:
+    """_fetch_via_serpapi returns topic titles from API response."""
+    from services.trends import _fetch_via_serpapi
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "trending_searches": [
+            {"query": "Trend 1"},
+            {"query": "Trend 2"},
+            {"other": "ignored"},
+        ]
+    }
+
+    with patch("services.trends.requests.get") as mock_get:
+        mock_get.return_value = mock_resp
+
+        result = _fetch_via_serpapi("US", "api-key")
+
+    assert result == ["Trend 1", "Trend 2"]
+
+
+def test_fetch_via_serpapi_error_returns_empty() -> None:
+    """_fetch_via_serpapi returns empty list on error."""
+    from services.trends import _fetch_via_serpapi
+
+    with patch("services.trends.requests.get") as mock_get:
+        mock_get.side_effect = Exception("Timeout")
+
+        result = _fetch_via_serpapi("US", "api-key")
+
+    assert result == []

--- a/apps/api/tests/test_trends_scraper.py
+++ b/apps/api/tests/test_trends_scraper.py
@@ -1,0 +1,134 @@
+"""Tests for the trends scraper service."""
+
+import csv
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from services.trends_scraper import _parse_trends_csv
+
+
+def test_parse_trends_csv_basic() -> None:
+    """_parse_trends_csv parses valid rows into trend items."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        writer = csv.writer(f)
+        writer.writerow(["AI News"])
+        writer.writerow(["Climate Summit"])
+        writer.writerow(["Sports Update"])
+        path = Path(f.name)
+
+    try:
+        result = _parse_trends_csv(path)
+        assert len(result) == 3
+        assert result[0]["title"] == "AI News"
+        assert result[1]["title"] == "Climate Summit"
+        assert result[2]["title"] == "Sports Update"
+    finally:
+        path.unlink()
+
+
+def test_parse_trends_csv_with_metadata() -> None:
+    """_parse_trends_csv includes search_volume and started when present."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        writer = csv.writer(f)
+        writer.writerow(["Breaking News", "1M+", "2h ago"])
+        writer.writerow(["Local Event", "500K"])
+        path = Path(f.name)
+
+    try:
+        result = _parse_trends_csv(path)
+        assert result[0]["title"] == "Breaking News"
+        assert result[0]["search_volume"] == "1M+"
+        assert result[0]["started"] == "2h ago"
+        assert result[1]["title"] == "Local Event"
+        assert result[1]["search_volume"] == "500K"
+        assert "started" not in result[1]
+    finally:
+        path.unlink()
+
+
+def test_parse_trends_csv_skips_headers() -> None:
+    """_parse_trends_csv skips header-like rows."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        writer = csv.writer(f)
+        writer.writerow(["Tendances"])
+        writer.writerow(["Valid Trend 1"])
+        writer.writerow(["Trend"])
+        writer.writerow(["Valid Trend 2"])
+        path = Path(f.name)
+
+    try:
+        result = _parse_trends_csv(path)
+        assert len(result) == 2
+        assert result[0]["title"] == "Valid Trend 1"
+        assert result[1]["title"] == "Valid Trend 2"
+    finally:
+        path.unlink()
+
+
+def test_parse_trends_csv_skips_comments() -> None:
+    """_parse_trends_csv skips rows starting with #."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        writer = csv.writer(f)
+        writer.writerow(["# comment"])
+        writer.writerow(["Real Topic"])
+        path = Path(f.name)
+
+    try:
+        result = _parse_trends_csv(path)
+        assert len(result) == 1
+        assert result[0]["title"] == "Real Topic"
+    finally:
+        path.unlink()
+
+
+def test_parse_trends_csv_deduplicates() -> None:
+    """_parse_trends_csv does not add duplicate titles."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        writer = csv.writer(f)
+        writer.writerow(["Duplicate"])
+        writer.writerow(["Duplicate"])
+        writer.writerow(["Other"])
+        path = Path(f.name)
+
+    try:
+        result = _parse_trends_csv(path)
+        assert len(result) == 2
+        assert result[0]["title"] == "Duplicate"
+        assert result[1]["title"] == "Other"
+    finally:
+        path.unlink()
+
+
+def test_parse_trends_csv_respects_limit() -> None:
+    """_parse_trends_csv stops at LIMIT (25) items."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        writer = csv.writer(f)
+        for i in range(30):
+            writer.writerow([f"Item {i}"])
+        path = Path(f.name)
+
+    try:
+        result = _parse_trends_csv(path)
+        assert len(result) == 25
+    finally:
+        path.unlink()
+
+
+def test_parse_trends_csv_empty_file() -> None:
+    """_parse_trends_csv returns empty list for empty file."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        path = Path(f.name)
+
+    try:
+        result = _parse_trends_csv(path)
+        assert result == []
+    finally:
+        path.unlink()
+
+
+def test_parse_trends_csv_nonexistent_returns_empty() -> None:
+    """_parse_trends_csv returns empty list for nonexistent path."""
+    result = _parse_trends_csv(Path("/nonexistent/path.csv"))
+    assert result == []

--- a/apps/api/tests/test_trends_store.py
+++ b/apps/api/tests/test_trends_store.py
@@ -1,0 +1,67 @@
+"""Tests for trends storage."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models import TrendsDocument
+
+
+def test_save_trends_upserts() -> None:
+    """save_trends calls update_one with upsert."""
+    from services.trends_store import save_trends
+
+    with patch("services.trends_store.get_trends_collection") as mock_get:
+        mock_coll = MagicMock()
+        mock_get.return_value = mock_coll
+
+        save_trends("US", [{"title": "Topic 1"}, {"title": "Topic 2"}], source="api")
+
+        mock_coll.update_one.assert_called_once()
+        call_args = mock_coll.update_one.call_args
+        assert call_args[0][0] == {"country": "US"}
+        assert "$set" in call_args[0][1]
+        assert call_args[0][1]["$set"]["topics"] == [{"title": "Topic 1"}, {"title": "Topic 2"}]
+        assert call_args[0][1]["$set"]["source"] == "api"
+        assert call_args[1]["upsert"] is True
+
+
+def test_get_trends_from_db_returns_none_when_empty() -> None:
+    """get_trends_from_db returns None when no document exists."""
+    from services.trends_store import get_trends_from_db
+
+    with patch("services.trends_store.get_trends_collection") as mock_get:
+        mock_coll = MagicMock()
+        mock_coll.find_one.return_value = None
+        mock_get.return_value = mock_coll
+
+        result = get_trends_from_db("US")
+
+        assert result is None
+
+
+def test_get_trends_from_db_returns_document() -> None:
+    """get_trends_from_db returns TrendsDocument when data exists."""
+    from services.trends_store import get_trends_from_db
+
+    now = datetime.now(timezone.utc)
+    doc = {
+        "country": "US",
+        "topics": [{"title": "A"}, {"title": "B"}],
+        "source": "api",
+        "fetched_at": now,
+        "updated_at": now,
+    }
+    with patch("services.trends_store.get_trends_collection") as mock_get:
+        mock_coll = MagicMock()
+        mock_coll.find_one.return_value = doc
+        mock_get.return_value = mock_coll
+
+        result = get_trends_from_db("US")
+
+        assert result is not None
+        assert isinstance(result, TrendsDocument)
+        assert result.country == "US"
+        assert [t["title"] for t in result.topics] == ["A", "B"]
+        assert result.source == "api"

--- a/apps/api/worker.py
+++ b/apps/api/worker.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Worker to fetch Google Trends (via scraper) and save to MongoDB.
+
+Scrapes https://trends.google.com/trending?geo=XX for each country.
+Run manually or schedule with cron (e.g. every 24 hours):
+
+  0 0 * * * /path/to/apps/api/run-worker.sh
+
+Set MONGODB_URI and MONGODB_DB for your environment.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Ensure apps/api is on path when run as module
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from services.trends import get_trending_topics
+from services.trends_store import save_trends
+
+# Countries to scrape (configurable via env: TRENDS_COUNTRIES=US,GB,FR,...)
+DEFAULT_COUNTRIES = ["US", "GB", "FR", "DE", "IN", "JP", "BR", "CA", "AU", "ES", "CR"]
+
+
+def run() -> None:
+    """Scrape trends for all configured countries and save to MongoDB."""
+    countries_str = os.getenv("TRENDS_COUNTRIES", "")
+    countries = [c.strip().upper() for c in countries_str.split(",") if c.strip()] if countries_str else DEFAULT_COUNTRIES
+
+    for country in countries:
+        try:
+            print(f"Fetching trends from Google Trends for {country}...")
+            topics, source = get_trending_topics(country)
+            save_trends(country, topics, source=source)
+            print(f"Saved {len(topics)} topics for {country} (source={source})")
+            for i, t in enumerate(topics[:5], 1):
+                title = t.get("title", t) if isinstance(t, dict) else t
+                vol = t.get("search_volume", "") if isinstance(t, dict) else ""
+                started = t.get("started", "") if isinstance(t, dict) else ""
+                extra = []
+                if vol:
+                    extra.append(f"volume={vol}")
+                if started:
+                    extra.append(f"started={started}")
+                suffix = f"  [{', '.join(extra)}]" if extra else ""
+                print(f"  {i}. {title}{suffix}")
+            if len(topics) > 5:
+                print(f"  ... and {len(topics) - 5} more")
+        except Exception as e:
+            print(f"Error fetching {country}: {e}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    run()

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -7,24 +7,24 @@ export const metadata: Metadata = {
 
 export default function DocsPage() {
   return (
-    <div className="min-h-screen bg-zinc-50 font-sans dark:bg-zinc-950">
-      <main className="mx-auto max-w-3xl px-6 py-16">
-        <h1 className="mb-4 text-3xl font-semibold text-zinc-900 dark:text-zinc-50">
+    <div className="min-h-screen bg-stone-50 font-sans dark:bg-stone-950">
+      <main className="mx-auto max-w-3xl px-8 py-16">
+        <h1 className="mb-3 text-[28px] font-semibold tracking-tight text-stone-900 dark:text-stone-50">
           Documentation
         </h1>
-        <p className="mb-8 text-lg text-zinc-600 dark:text-zinc-400">
+        <p className="mb-10 text-[15px] leading-relaxed text-stone-600 dark:text-stone-400">
           Welcome to the Hanfani AI documentation. Feature docs and guides will be
           added here.
         </p>
-        <div className="space-y-4">
+        <div className="space-y-3">
           <a
             href="/status"
-            className="block rounded-lg border border-zinc-200 bg-white px-6 py-4 transition-colors hover:border-zinc-300 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-700"
+            className="block rounded-2xl bg-white px-6 py-5 shadow-sm transition hover:shadow-md dark:bg-stone-900 dark:shadow-stone-950/50 dark:hover:shadow-stone-900/50"
           >
-            <h2 className="font-medium text-zinc-900 dark:text-zinc-50">
+            <h2 className="font-medium text-stone-900 dark:text-stone-50">
               Status Page
             </h2>
-            <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+            <p className="mt-1.5 text-[14px] text-stone-500 dark:text-stone-400">
               Check app and API availability
             </p>
           </a>
@@ -32,12 +32,12 @@ export default function DocsPage() {
             href={`${process.env.NEXT_PUBLIC_API_URL || "http://localhost:8001"}/docs`}
             target="_blank"
             rel="noopener noreferrer"
-            className="block rounded-lg border border-zinc-200 bg-white px-6 py-4 transition-colors hover:border-zinc-300 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-700"
+            className="block rounded-2xl bg-white px-6 py-5 shadow-sm transition hover:shadow-md dark:bg-stone-900 dark:shadow-stone-950/50 dark:hover:shadow-stone-900/50"
           >
-            <h2 className="font-medium text-zinc-900 dark:text-zinc-50">
+            <h2 className="font-medium text-stone-900 dark:text-stone-50">
               API Documentation (Swagger)
             </h2>
-            <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+            <p className="mt-1.5 text-[14px] text-stone-500 dark:text-stone-400">
               Interactive API docs
             </p>
           </a>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2,14 +2,15 @@
 
 @custom-variant dark (&:where(html.dark, html.dark *));
 
+/* Miro/Basecamp-inspired: soft, calm, generous whitespace */
 :root {
-  --background: #f4f4f5;
-  --foreground: #171717;
+  --background: #fafaf9;
+  --foreground: #1c1917;
 }
 
 html.dark {
-  --background: #09090b;
-  --foreground: #ededed;
+  --background: #0c0a09;
+  --foreground: #fafaf9;
 }
 
 @theme inline {
@@ -22,5 +23,6 @@ html.dark {
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans), system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,53 +1,31 @@
-import Image from "next/image";
+import Link from "next/link";
 
 export default function Home() {
   return (
-    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-zinc-100 font-sans dark:bg-zinc-950">
-      <main className="flex flex-1 flex-col items-center justify-center gap-6 overflow-hidden px-8 bg-zinc-50 dark:bg-zinc-950 sm:items-start sm:px-16">
-        <div className="flex flex-col items-center gap-4 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-4xl text-5xl font-bold leading-tight tracking-tight text-black dark:text-zinc-50 sm:text-6xl md:text-7xl lg:text-8xl">
-            To get started, edit the page.tsx file.
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-stone-50 font-sans dark:bg-stone-950">
+      <main className="flex flex-1 flex-col items-center justify-center gap-10 overflow-hidden px-8 sm:px-16">
+        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
+          <h1 className="max-w-3xl text-4xl font-semibold leading-tight tracking-tight text-stone-900 dark:text-stone-50 sm:text-5xl md:text-6xl">
+            Bridging Google Trends and Social Intelligence
           </h1>
-          <p className="max-w-md text-base leading-6 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
+          <p className="max-w-xl text-[17px] leading-relaxed text-stone-600 dark:text-stone-400">
+            Discover what&apos;s trending, explore coverage across news and platforms,
+            and stay ahead with autonomous AI agents.
           </p>
         </div>
-        <div className="flex flex-col gap-3 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new/clone?repository-url=https://github.com/azizmashkour/hanfani"
-            target="_blank"
-            rel="noopener noreferrer"
+        <div className="flex flex-col gap-4 sm:flex-row">
+          <Link
+            href="/trends"
+            className="flex h-12 items-center justify-center rounded-xl bg-stone-900 px-8 text-[15px] font-medium text-white transition-colors hover:bg-stone-800 dark:bg-stone-100 dark:text-stone-900 dark:hover:bg-stone-200"
           >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
+            Explore Trends
+          </Link>
+          <Link
             href="/docs"
+            className="flex h-12 items-center justify-center rounded-xl border border-stone-200 bg-white px-8 text-[15px] font-medium text-stone-700 transition-colors hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-300 dark:hover:bg-stone-800"
           >
             Documentation
-          </a>
+          </Link>
         </div>
       </main>
     </div>

--- a/apps/web/src/app/status/page.tsx
+++ b/apps/web/src/app/status/page.tsx
@@ -92,26 +92,26 @@ export default function StatusPage() {
     },
     checking: {
       label: "Checking...",
-      color: "bg-zinc-400",
-      textColor: "text-zinc-600 dark:text-zinc-400",
-      dotColor: "bg-zinc-400 animate-pulse",
+      color: "bg-stone-400",
+      textColor: "text-stone-600 dark:text-stone-400",
+      dotColor: "bg-stone-400 animate-pulse",
     },
   };
 
   const config = statusConfig[overallStatus];
 
   return (
-    <div className="min-h-screen bg-zinc-50 font-sans dark:bg-zinc-950">
-      <main className="mx-auto max-w-2xl px-6 py-16">
-        <h1 className="mb-2 text-2xl font-semibold text-zinc-900 dark:text-zinc-50">
+    <div className="min-h-screen bg-stone-50 font-sans dark:bg-stone-950">
+      <main className="mx-auto max-w-2xl px-8 py-16">
+        <h1 className="mb-2 text-[28px] font-semibold tracking-tight text-stone-900 dark:text-stone-50">
           Hanfani AI Status
         </h1>
-        <p className="mb-8 text-zinc-600 dark:text-zinc-400">
+        <p className="mb-10 text-[15px] text-stone-600 dark:text-stone-400">
           Real-time availability of our services
         </p>
 
         {/* Overall status */}
-        <div className="mb-10 rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
+        <div className="mb-12 rounded-2xl bg-white p-6 shadow-sm dark:bg-stone-900 dark:shadow-stone-950/50">
           <div className="flex items-center gap-3">
             <span
               className={`h-3 w-3 rounded-full ${config.dotColor}`}
@@ -122,27 +122,27 @@ export default function StatusPage() {
             </span>
           </div>
           {lastUpdated && !isLoading && (
-            <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+            <p className="mt-2 text-[14px] text-stone-500 dark:text-stone-400">
               Last updated: {lastUpdated.toLocaleTimeString()}
             </p>
           )}
         </div>
 
         {/* Service list */}
-        <div className="space-y-4">
+        <div className="space-y-3">
           {services.map((service) => {
             const s = statusConfig[service.status] || statusConfig.checking;
             return (
               <div
                 key={service.name}
-                className="flex items-center justify-between rounded-lg border border-zinc-200 bg-white px-6 py-4 dark:border-zinc-800 dark:bg-zinc-900"
+                className="flex items-center justify-between rounded-2xl bg-white px-6 py-4 shadow-sm dark:bg-stone-900 dark:shadow-stone-950/50"
               >
                 <div>
-                  <p className="font-medium text-zinc-900 dark:text-zinc-50">
+                  <p className="font-medium text-stone-900 dark:text-stone-50">
                     {service.name}
                   </p>
                   {service.message && (
-                    <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                    <p className="text-[14px] text-stone-500 dark:text-stone-400">
                       {service.message}
                     </p>
                   )}
@@ -152,7 +152,7 @@ export default function StatusPage() {
                     className={`h-2.5 w-2.5 rounded-full ${s.dotColor}`}
                     aria-hidden
                   />
-                  <span className={`text-sm font-medium ${s.textColor}`}>
+                  <span className={`text-[14px] font-medium ${s.textColor}`}>
                     {s.label}
                   </span>
                 </div>
@@ -164,7 +164,7 @@ export default function StatusPage() {
         <button
           onClick={checkServices}
           disabled={isLoading}
-          className="mt-8 cursor-pointer rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+          className="mt-10 cursor-pointer rounded-xl bg-stone-900 px-5 py-2.5 text-[14px] font-medium text-white transition-colors hover:bg-stone-800 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-stone-100 dark:text-stone-900 dark:hover:bg-stone-200"
         >
           {isLoading ? "Checking..." : "Refresh"}
         </button>

--- a/apps/web/src/app/trends/details/page.tsx
+++ b/apps/web/src/app/trends/details/page.tsx
@@ -1,0 +1,374 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
+
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:8001";
+
+const VIEW_KEY = "hanfani-details-view";
+const PAGE_SIZE = 12;
+
+type ViewMode = "list" | "cards";
+
+const COUNTRIES = [
+  { code: "US", name: "United States" },
+  { code: "GB", name: "United Kingdom" },
+  { code: "FR", name: "France" },
+  { code: "DE", name: "Germany" },
+  { code: "IN", name: "India" },
+  { code: "JP", name: "Japan" },
+  { code: "BR", name: "Brazil" },
+  { code: "CA", name: "Canada" },
+  { code: "AU", name: "Australia" },
+  { code: "ES", name: "Spain" },
+  { code: "CR", name: "Costa Rica" },
+] as const;
+
+interface MentionItem {
+  title: string;
+  source: string;
+  source_type?: string;
+  link: string;
+  snippet?: string;
+  date?: string;
+  iso_date?: string;
+  authors?: string[];
+  thumbnail?: string;
+  position?: number;
+}
+
+interface MentionsResponse {
+  topic: string;
+  country: string;
+  mentions: MentionItem[];
+}
+
+function DetailsContent() {
+  const searchParams = useSearchParams();
+  const topicParam = searchParams.get("topic") || "";
+  const countryParam = searchParams.get("country") || "US";
+
+  const [data, setData] = useState<MentionsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [viewMode, setViewMode] = useState<ViewMode>("list");
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(VIEW_KEY) as ViewMode | null;
+      if (stored === "list" || stored === "cards") setViewMode(stored);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const setView = (v: ViewMode) => {
+    setViewMode(v);
+    try {
+      localStorage.setItem(VIEW_KEY, v);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  useEffect(() => {
+    if (!topicParam) {
+      setData(null);
+      setError("No topic specified");
+      setIsLoading(false);
+      return;
+    }
+
+    const fetchMentions = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams({
+          topic: topicParam,
+          country: countryParam,
+        });
+        const res = await fetch(`${API_URL}/trends/mentions?${params}`, {
+          signal: AbortSignal.timeout(15000),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.detail || `HTTP ${res.status}`);
+        }
+        const json: MentionsResponse = await res.json();
+        setData(json);
+      } catch (err) {
+        setData(null);
+        setError(err instanceof Error ? err.message : "Failed to fetch mentions");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchMentions();
+  }, [topicParam, countryParam]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [topicParam, countryParam]);
+
+  if (!topicParam) {
+    return (
+      <div className="rounded-2xl border border-amber-200/80 bg-amber-50 px-6 py-5 dark:border-amber-900/50 dark:bg-amber-950/30">
+        <p className="mb-3 text-[15px] text-amber-800 dark:text-amber-200">
+          Select a topic from the trends list to see articles and platforms.
+        </p>
+        <Link
+          href="/trends"
+          className="text-[14px] font-medium text-amber-700 underline hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100"
+        >
+          ← Back to Trends
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center gap-4">
+        <Link
+          href="/trends"
+          className="text-[14px] font-medium text-stone-600 hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-100"
+        >
+          ← Back to Trends
+        </Link>
+        <span className="text-stone-300 dark:text-stone-600">·</span>
+        <span className="text-[14px] text-stone-500 dark:text-stone-400">
+          {COUNTRIES.find((c) => c.code === countryParam)?.name ?? countryParam}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-[28px] font-semibold tracking-tight text-stone-900 dark:text-stone-50">
+            Coverage: {decodeURIComponent(topicParam)}
+          </h1>
+          <p className="mt-2 text-[15px] leading-relaxed text-stone-600 dark:text-stone-400">
+            News articles and platforms discussing this topic, ranked by relevance and recency.
+          </p>
+        </div>
+        <div className="flex items-center gap-1 rounded-lg border border-stone-200 bg-white p-1 dark:border-stone-700 dark:bg-stone-900">
+          <button
+            type="button"
+            onClick={() => setView("list")}
+            aria-label="List view"
+            title="List view"
+            className={`inline-flex items-center justify-center rounded-md p-2 transition ${
+              viewMode === "list"
+                ? "bg-stone-100 text-stone-900 dark:bg-stone-800 dark:text-stone-50"
+                : "text-stone-500 hover:bg-stone-50 hover:text-stone-700 dark:text-stone-400 dark:hover:bg-stone-800 dark:hover:text-stone-300"
+            }`}
+          >
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            onClick={() => setView("cards")}
+            aria-label="Card view"
+            title="Card view"
+            className={`inline-flex items-center justify-center rounded-md p-2 transition ${
+              viewMode === "cards"
+                ? "bg-stone-100 text-stone-900 dark:bg-stone-800 dark:text-stone-50"
+                : "text-stone-500 hover:bg-stone-50 hover:text-stone-700 dark:text-stone-400 dark:hover:bg-stone-800 dark:hover:text-stone-300"
+            }`}
+          >
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center gap-3 text-[15px] text-stone-500 dark:text-stone-400">
+          <span className="h-4 w-4 animate-spin rounded-full border-2 border-stone-200 border-t-stone-500 dark:border-stone-700 dark:border-t-stone-400" />
+          Loading articles...
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-2xl border border-red-200/80 bg-red-50 px-6 py-5 text-[15px] text-red-800 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-200">
+          {error}
+          {error.includes("SERPAPI") || error.includes("401") ? (
+            <p className="mt-3 text-[14px]">
+              Set SERPAPI_KEY in the API to fetch live news. Get a key at{" "}
+              <a
+                href="https://serpapi.com/manage-api-key"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium underline"
+              >
+                serpapi.com
+              </a>
+            </p>
+          ) : null}
+        </div>
+      )}
+
+      {!isLoading && !error && data && (() => {
+          const total = data.mentions.length;
+          const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+          const start = (page - 1) * PAGE_SIZE;
+          const paginatedMentions = data.mentions.slice(start, start + PAGE_SIZE);
+          return (
+        <div className="space-y-6">
+          <p className="text-[14px] text-stone-500 dark:text-stone-400">
+            {total} article
+            {total !== 1 ? "s" : ""} and platform
+            {total !== 1 ? "s" : ""} found
+          </p>
+
+          {viewMode === "list" ? (
+            <ul className="space-y-4">
+              {paginatedMentions.map((m, j) => {
+                const i = start + j;
+                return (
+                <li
+                  key={`${m.link}-${i}`}
+                  className="group relative overflow-hidden rounded-xl border border-stone-200 bg-white transition hover:border-stone-300 hover:shadow-[0_4px_12px_rgba(0,0,0,0.08)] dark:border-stone-700/80 dark:bg-stone-900 dark:hover:border-stone-600 dark:hover:shadow-[0_4px_12px_rgba(0,0,0,0.25)]"
+                >
+                  <div className="absolute left-0 top-0 h-full w-1 bg-stone-200 transition group-hover:bg-stone-400 dark:bg-stone-600 dark:group-hover:bg-stone-500" />
+                  <a
+                    href={m.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block p-5 pl-6"
+                  >
+                    <div className="flex gap-5">
+                      {m.thumbnail && (
+                        <img
+                          src={m.thumbnail}
+                          alt=""
+                          className="h-24 w-32 shrink-0 rounded-lg object-cover"
+                        />
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <h2 className="font-medium text-stone-900 dark:text-stone-50 hover:underline">
+                          {m.title}
+                        </h2>
+                        <div className="mt-1.5 flex flex-wrap items-center gap-2 text-[13px] text-stone-500 dark:text-stone-400">
+                          <span className="font-medium">{m.source}</span>
+                          {m.date && <span>· {m.date}</span>}
+                          {m.authors && m.authors.length > 0 && (
+                            <span>· {m.authors.slice(0, 2).join(", ")}</span>
+                          )}
+                        </div>
+                        {m.snippet && (
+                          <p className="mt-2 line-clamp-2 text-[14px] leading-relaxed text-stone-600 dark:text-stone-400">
+                            {m.snippet}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </a>
+                </li>
+              );
+              })}
+            </ul>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {paginatedMentions.map((m, j) => {
+                const i = start + j;
+                return (
+                <a
+                  key={`${m.link}-${i}`}
+                  href={m.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group relative flex flex-col overflow-hidden rounded-xl border border-stone-200 bg-white transition hover:border-stone-300 hover:shadow-[0_4px_12px_rgba(0,0,0,0.08)] dark:border-stone-700/80 dark:bg-stone-900 dark:hover:border-stone-600 dark:hover:shadow-[0_4px_12px_rgba(0,0,0,0.25)]"
+                >
+                  <div className="absolute left-0 top-0 h-full w-1 bg-stone-200 transition group-hover:bg-stone-400 dark:bg-stone-600 dark:group-hover:bg-stone-500" />
+                  <div className="flex flex-1 flex-col p-4 pl-5">
+                    {m.thumbnail && (
+                      <img
+                        src={m.thumbnail}
+                        alt=""
+                        className="mb-3 h-32 w-full rounded-lg object-cover"
+                      />
+                    )}
+                    <span className="mb-1 text-[11px] font-medium uppercase tracking-wider text-stone-400 dark:text-stone-500">
+                      {m.source}
+                    </span>
+                    <span className="font-medium text-stone-900 dark:text-stone-50 line-clamp-2 group-hover:text-stone-700 dark:group-hover:text-stone-200">
+                      {m.title}
+                    </span>
+                    {m.date && (
+                      <span className="mt-2 text-[13px] text-stone-500 dark:text-stone-400">
+                        {m.date}
+                      </span>
+                    )}
+                    {m.snippet && (
+                      <p className="mt-2 line-clamp-2 text-[13px] text-stone-500 dark:text-stone-400">
+                        {m.snippet}
+                      </p>
+                    )}
+                  </div>
+                </a>
+              );
+              })}
+            </div>
+          )}
+
+          {total === 0 ? (
+            <p className="rounded-2xl bg-white px-8 py-12 text-center text-[15px] text-stone-500 dark:bg-stone-900 dark:text-stone-400">
+              No articles found for this topic. Try a different country or check that SERPAPI_KEY is set.
+            </p>
+          ) : totalPages > 1 ? (
+            <nav className="flex items-center justify-between border-t border-stone-200 pt-6 dark:border-stone-700">
+              <p className="text-[13px] text-stone-500 dark:text-stone-400">
+                Page {page} of {totalPages}
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page <= 1}
+                  className="rounded-lg border border-stone-200 bg-white px-3 py-1.5 text-[13px] font-medium text-stone-700 transition disabled:opacity-40 disabled:cursor-not-allowed hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-300 dark:hover:bg-stone-800"
+                >
+                  Previous
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={page >= totalPages}
+                  className="rounded-lg border border-stone-200 bg-white px-3 py-1.5 text-[13px] font-medium text-stone-700 transition disabled:opacity-40 disabled:cursor-not-allowed hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-300 dark:hover:bg-stone-800"
+                >
+                  Next
+                </button>
+              </div>
+            </nav>
+          ) : null}
+        </div>
+          );
+        })()}
+    </div>
+  );
+}
+
+export default function TrendDetailsPage() {
+  return (
+    <div className="flex flex-1 flex-col overflow-auto bg-stone-50 dark:bg-stone-950">
+      <main className="mx-auto w-full max-w-5xl flex-1 px-8 py-14">
+        <Suspense
+          fallback={
+            <div className="flex items-center gap-3 text-[15px] text-stone-500 dark:text-stone-400">
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-stone-200 border-t-stone-500" />
+              Loading...
+            </div>
+          }
+        >
+          <DetailsContent />
+        </Suspense>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/app/trends/layout.tsx
+++ b/apps/web/src/app/trends/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Trending Topics | Hanfani AI",
+  description: "Top Google Trends by country - identify what's relevant to your audience",
+};
+
+export default function TrendsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/apps/web/src/app/trends/page.tsx
+++ b/apps/web/src/app/trends/page.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:8001";
+
+const VIEW_KEY = "hanfani-trends-view";
+const PAGE_SIZE = 10;
+
+type ViewMode = "list" | "cards";
+
+const COUNTRIES = [
+  { code: "US", name: "United States" },
+  { code: "GB", name: "United Kingdom" },
+  { code: "FR", name: "France" },
+  { code: "DE", name: "Germany" },
+  { code: "IN", name: "India" },
+  { code: "JP", name: "Japan" },
+  { code: "BR", name: "Brazil" },
+  { code: "CA", name: "Canada" },
+  { code: "AU", name: "Australia" },
+  { code: "ES", name: "Spain" },
+  { code: "CR", name: "Costa Rica" },
+] as const;
+
+interface TrendItem {
+  title: string;
+  search_volume?: string;
+  started?: string;
+}
+
+interface TrendsResponse {
+  country: string;
+  topics: TrendItem[] | string[];
+  source?: "api" | "fallback" | "db" | "scraper" | "serpapi";
+  fetched_at?: string;
+}
+
+export default function TrendsPage() {
+  const [country, setCountry] = useState("US");
+  const [data, setData] = useState<TrendsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [viewMode, setViewMode] = useState<ViewMode>("list");
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(VIEW_KEY) as ViewMode | null;
+      if (stored === "list" || stored === "cards") setViewMode(stored);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const setView = (v: ViewMode) => {
+    setViewMode(v);
+    try {
+      localStorage.setItem(VIEW_KEY, v);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  useEffect(() => {
+    const fetchTrends = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`${API_URL}/trends?country=${country}`, {
+          signal: AbortSignal.timeout(10000),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.detail || `HTTP ${res.status}`);
+        }
+        const json: TrendsResponse = await res.json();
+        setData(json);
+      } catch (err) {
+        setData(null);
+        setError(err instanceof Error ? err.message : "Failed to fetch trends");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchTrends();
+  }, [country]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [country]);
+
+  return (
+    <div className="flex flex-1 flex-col overflow-auto bg-stone-50 dark:bg-stone-950">
+      <main className="mx-auto w-full max-w-5xl flex-1 px-8 py-14">
+        <h1 className="mb-2 text-[28px] font-semibold tracking-tight text-stone-900 dark:text-stone-50">
+          Trending Topics
+        </h1>
+        <p className="mb-10 text-[15px] leading-relaxed text-stone-600 dark:text-stone-400">
+          Top Google Trends for your audience. Select a country to see what&apos;s
+          trending.
+        </p>
+
+        <div className="mb-12 flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <label
+              htmlFor="country"
+              className="mb-2 block text-[13px] font-medium text-stone-700 dark:text-stone-300"
+            >
+              Country
+            </label>
+            <select
+              id="country"
+              value={country}
+              onChange={(e) => setCountry(e.target.value)}
+              className="w-full max-w-xs rounded-lg border border-stone-200 bg-white px-4 py-2.5 text-[14px] text-stone-900 transition focus:border-stone-400 focus:outline-none focus:ring-2 focus:ring-stone-200/50 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-50 dark:focus:border-stone-600 dark:focus:ring-stone-600/30"
+            >
+              {COUNTRIES.map((c) => (
+                <option key={c.code} value={c.code}>
+                  {c.name} ({c.code})
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center gap-1 rounded-lg border border-stone-200 bg-white p-1 dark:border-stone-700 dark:bg-stone-900">
+            <button
+              type="button"
+              onClick={() => setView("list")}
+              aria-label="List view"
+              title="List view"
+              className={`inline-flex items-center justify-center rounded-md p-2 transition ${
+                viewMode === "list"
+                  ? "bg-stone-100 text-stone-900 dark:bg-stone-800 dark:text-stone-50"
+                  : "text-stone-500 hover:bg-stone-50 hover:text-stone-700 dark:text-stone-400 dark:hover:bg-stone-800 dark:hover:text-stone-300"
+              }`}
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              onClick={() => setView("cards")}
+              aria-label="Card view"
+              title="Card view"
+              className={`inline-flex items-center justify-center rounded-md p-2 transition ${
+                viewMode === "cards"
+                  ? "bg-stone-100 text-stone-900 dark:bg-stone-800 dark:text-stone-50"
+                  : "text-stone-500 hover:bg-stone-50 hover:text-stone-700 dark:text-stone-400 dark:hover:bg-stone-800 dark:hover:text-stone-300"
+              }`}
+            >
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {isLoading && (
+          <div className="flex items-center gap-3 text-[15px] text-stone-500 dark:text-stone-400">
+            <span className="h-4 w-4 animate-spin rounded-full border-2 border-stone-200 border-t-stone-500 dark:border-stone-700 dark:border-t-stone-400" />
+            Loading trends...
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-xl border border-red-200/80 bg-red-50 px-5 py-4 text-[15px] text-red-800 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-200">
+            {error}
+          </div>
+        )}
+
+        {!isLoading && !error && data && (() => {
+          const total = data.topics.length;
+          const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+          const start = (page - 1) * PAGE_SIZE;
+          const paginatedTopics = data.topics.slice(start, start + PAGE_SIZE);
+          return (
+          <div className="space-y-6">
+            <p className="text-[14px] text-stone-500 dark:text-stone-400">
+              {total} trending topic
+              {total !== 1 ? "s" : ""} in {data.country}
+              {data.source === "fallback" && (
+                <span className="ml-2 rounded-lg bg-amber-100 px-2 py-0.5 text-[13px] text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+                  Sample data
+                </span>
+              )}
+              {data.source === "db" && data.fetched_at && (
+                <span className="ml-2 text-stone-400 dark:text-stone-500">
+                  Cached {new Date(data.fetched_at).toLocaleString()}
+                </span>
+              )}
+            </p>
+
+            {viewMode === "list" ? (
+              <ul className="mx-auto max-w-2xl space-y-3">
+                {paginatedTopics.map((topic, j) => {
+                  const i = start + j;
+                  const t = typeof topic === "string" ? { title: topic } : topic;
+                  const detailsUrl = `/trends/details?topic=${encodeURIComponent(t.title)}&country=${country}`;
+                  return (
+                    <li
+                      key={`${t.title}-${i}`}
+                      className="rounded-2xl bg-white shadow-sm transition hover:shadow-md dark:bg-stone-900 dark:shadow-stone-950/50 dark:hover:shadow-stone-900/50"
+                    >
+                      <Link
+                        href={detailsUrl}
+                        className="flex items-center gap-4 px-5 py-4"
+                      >
+                        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-stone-100 text-[14px] font-medium text-stone-600 dark:bg-stone-800 dark:text-stone-400">
+                          {i + 1}
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <span className="block font-medium text-stone-900 dark:text-stone-50">
+                            {t.title}
+                          </span>
+                          {(t.search_volume || t.started) && (
+                            <span className="mt-0.5 block text-[13px] text-stone-500 dark:text-stone-400">
+                              {[t.search_volume, t.started].filter(Boolean).join(" · ")}
+                            </span>
+                          )}
+                        </div>
+                        <span className="shrink-0 text-[13px] text-stone-400 dark:text-stone-500">
+                          View coverage →
+                        </span>
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {paginatedTopics.map((topic, j) => {
+                  const i = start + j;
+                  const t = typeof topic === "string" ? { title: topic } : topic;
+                  const detailsUrl = `/trends/details?topic=${encodeURIComponent(t.title)}&country=${country}`;
+                  return (
+                    <Link
+                      key={`${t.title}-${i}`}
+                      href={detailsUrl}
+                      className="group relative flex flex-col overflow-hidden rounded-xl border border-stone-200 bg-white transition hover:border-stone-300 hover:shadow-[0_4px_12px_rgba(0,0,0,0.08)] dark:border-stone-700/80 dark:bg-stone-900 dark:hover:border-stone-600 dark:hover:shadow-[0_4px_12px_rgba(0,0,0,0.25)]"
+                    >
+                      <div className="absolute left-0 top-0 h-full w-1 bg-stone-200 transition group-hover:bg-stone-400 dark:bg-stone-600 dark:group-hover:bg-stone-500" />
+                      <div className="flex flex-1 flex-col p-4 pl-5">
+                        <span className="mb-1 text-[11px] font-medium uppercase tracking-wider text-stone-400 dark:text-stone-500">
+                          #{i + 1}
+                        </span>
+                        <span className="font-medium text-stone-900 dark:text-stone-50 group-hover:text-stone-700 dark:group-hover:text-stone-200">
+                          {t.title}
+                        </span>
+                        {(t.search_volume || t.started) && (
+                          <span className="mt-2 text-[13px] text-stone-500 dark:text-stone-400">
+                            {[t.search_volume, t.started].filter(Boolean).join(" · ")}
+                          </span>
+                        )}
+                        <span className="mt-3 text-[13px] font-medium text-stone-500 dark:text-stone-400 group-hover:text-stone-700 dark:group-hover:text-stone-300">
+                          View coverage →
+                        </span>
+                      </div>
+                    </Link>
+                  );
+                })}
+              </div>
+            )}
+
+            {total === 0 ? (
+              <p className="mx-auto max-w-2xl rounded-2xl bg-white px-6 py-10 text-center text-[15px] text-stone-500 dark:bg-stone-900 dark:text-stone-400">
+                No trending topics available for this country right now.
+              </p>
+            ) : totalPages > 1 ? (
+              <nav className={`flex items-center justify-between border-t border-stone-200 pt-6 dark:border-stone-700 ${viewMode === "list" ? "mx-auto max-w-2xl" : ""}`}>
+                <p className="text-[13px] text-stone-500 dark:text-stone-400">
+                  Page {page} of {totalPages}
+                </p>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    disabled={page <= 1}
+                    className="rounded-lg border border-stone-200 bg-white px-3 py-1.5 text-[13px] font-medium text-stone-700 transition disabled:opacity-40 disabled:cursor-not-allowed hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-300 dark:hover:bg-stone-800"
+                  >
+                    Previous
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                    disabled={page >= totalPages}
+                    className="rounded-lg border border-stone-200 bg-white px-3 py-1.5 text-[13px] font-medium text-stone-700 transition disabled:opacity-40 disabled:cursor-not-allowed hover:bg-stone-50 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-300 dark:hover:bg-stone-800"
+                  >
+                    Next
+                  </button>
+                </div>
+              </nav>
+            ) : null}
+          </div>
+          );
+        })()}
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -3,8 +3,8 @@ export default function Footer() {
   const buildDate = process.env.NEXT_PUBLIC_BUILD_DATE ?? new Date().toISOString().split("T")[0];
 
   return (
-    <footer className="mt-auto border-t border-zinc-200 bg-zinc-50 py-4 dark:border-zinc-800 dark:bg-zinc-950">
-      <div className="mx-auto flex max-w-3xl flex-col items-center justify-between gap-2 px-6 text-sm text-zinc-500 dark:text-zinc-400 sm:flex-row">
+    <footer className="mt-auto border-t border-stone-200/80 bg-white/80 py-6 dark:border-stone-700/50 dark:bg-stone-950/80">
+      <div className="mx-auto flex max-w-5xl flex-col items-center justify-between gap-2 px-8 text-[13px] text-stone-500 dark:text-stone-400 sm:flex-row">
         <span>Hanfani AI v{version}</span>
         <span>Built {buildDate}</span>
       </div>

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -3,25 +3,31 @@ import ThemeToggle from "./ThemeToggle";
 
 export default function Header() {
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-zinc-200 bg-zinc-50 py-4 dark:border-zinc-800 dark:bg-zinc-950">
-      <div className="mx-auto flex items-center justify-between px-6">
+    <header className="sticky top-0 z-50 w-full border-b border-stone-200/80 bg-white/95 py-5 backdrop-blur-sm dark:border-stone-700/50 dark:bg-stone-950/95">
+      <div className="mx-auto flex max-w-5xl items-center justify-between px-8">
         <Link
           href="/"
-          className="inline-flex items-baseline font-bold tracking-tight text-black dark:text-zinc-50"
+          className="inline-flex items-baseline font-semibold tracking-tight text-stone-900 dark:text-stone-50"
         >
-          <span className="text-2xl">Hanfani</span>
-          <span className="ml-0.5 text-base">.AI</span>
+          <span className="text-xl">Hanfani</span>
+          <span className="ml-0.5 text-sm text-stone-500 dark:text-stone-400">.AI</span>
         </Link>
-        <nav className="flex items-center gap-8">
+        <nav className="flex items-center gap-10">
+          <Link
+            href="/trends"
+            className="text-[15px] text-stone-600 transition-colors hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-50"
+          >
+            Trends
+          </Link>
           <Link
             href="/docs"
-            className="text-base font-normal text-zinc-600 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
+            className="text-[15px] text-stone-600 transition-colors hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-50"
           >
             Docs
           </Link>
           <Link
             href="/status"
-            className="text-base font-normal text-zinc-600 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
+            className="text-[15px] text-stone-600 transition-colors hover:text-stone-900 dark:text-stone-400 dark:hover:text-stone-50"
           >
             Status
           </Link>

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -33,7 +33,7 @@ export default function ThemeToggle() {
     <button
       type="button"
       onClick={toggle}
-      className="cursor-pointer rounded-full p-2 text-zinc-600 transition-colors hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
+      className="cursor-pointer rounded-xl p-2 text-stone-600 transition-colors hover:bg-stone-100 hover:text-stone-900 dark:text-stone-400 dark:hover:bg-stone-800 dark:hover:text-stone-50"
       aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
     >
       {isDark ? (


### PR DESCRIPTION
- Add Google Trends scraper (Playwright) with search_volume and started time
- Add topic mentions API (SerpApi) for news articles per trend
- Add trends details page with articles ranked by relevance
- Miro/Basecamp-inspired design: stone palette, rounded cards, soft shadows
- List/card view toggle with Vercel/Supabase-style cards (border, left accent)
- Pagination (10 trends/page, 12 articles/page)
- Consistent layout: centered list view, no flip on view switch
- MongoDB storage for trends, worker for scheduled scraping